### PR TITLE
docs(jump_compound_annotator): fix broken Zenodo link in README

### DIFF
--- a/libs/jump_compound_annotator/README.md
+++ b/libs/jump_compound_annotator/README.md
@@ -4,7 +4,7 @@ Tools to collect and standardize drug-target interaction (DTI) annotations for J
 
 > **Using MOTIVE for ML?** See the [MOTIVE wiki](https://github.com/carpenter-singh-lab/2024_Arevalo_NeurIPS_MotiVE/wiki) for dataset documentation and processed data.
 >
-> **Want pre-computed annotations?** See the [Zenodo deposit](https://doi.org/10.5281/zenodo.XXXXXXX) for ready-to-use outputs with full schema documentation.
+> **Want pre-computed annotations?** See the [Zenodo deposit](https://doi.org/10.5281/zenodo.18197517) for ready-to-use outputs with full schema documentation.
 
 This repository contains the **pipeline code** to regenerate DTI annotations from scratch or extend to other compound sets.
 


### PR DESCRIPTION
## Summary
- Replaces the `XXXXXXX` placeholder DOI in `libs/jump_compound_annotator/README.md` with the actual Zenodo record (`10.5281/zenodo.18197517`), so the pre-computed DTI annotations link resolves correctly.

Closes #106

## Test plan
- [x] Confirm https://doi.org/10.5281/zenodo.18197517 resolves to the intended JUMP DTI deposit
- [x] Render the README on GitHub and click the "Zenodo deposit" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)